### PR TITLE
Fix error, rename class

### DIFF
--- a/https-all-the-things.php
+++ b/https-all-the-things.php
@@ -10,7 +10,7 @@
  * License: GPL2
  */
 
-class makeitsecure_ssl {
+class Https_All_The_Things {
 
 	# Notable SSL tickets:
 	# https://core.trac.wordpress.org/ticket/15928
@@ -120,7 +120,7 @@ class makeitsecure_ssl {
 		static $instance = false;
 
 		if ( ! $instance ) {
-			$instance = new makeitsecure_ssl;
+			$instance = new Https_All_The_Things;
 		}
 
 		return $instance;
@@ -129,4 +129,4 @@ class makeitsecure_ssl {
 
 }
 
-makeitsecure_ssl::init();
+Https_All_The_Things::init();

--- a/https-all-the-things.php
+++ b/https-all-the-things.php
@@ -20,7 +20,7 @@ class Https_All_The_Things {
 
 	public function __construct() {
 
-		add_action( 'init',                         array( $this, 'action_init' ), 99 );
+		// add_action( 'init',                         array( $this, 'action_init' ), 99 );
 
 		if ( !is_admin() ) {
 
@@ -39,6 +39,25 @@ class Https_All_The_Things {
 		add_filter( 'option_wpurl',          array( $this, 'enforce_admin_scheme' ) );
 		add_filter( 'wp_get_attachment_url', 'set_url_scheme', 1 );
 		add_filter( 'wp_insert_post_data',   array( $this, 'wp_insert_post_data_guid' ) );
+
+	}
+
+	/**
+	 * Force the correct scheme on the front end via a redirect, if necessary.
+	 *
+	 * @action init
+	 */
+	public function action_init() {
+
+		// No need for action if we're either using CLI or
+		// over HTTPS already
+		if ( is_ssl() || "cli" == php_sapi_name() ) {
+			return;
+		}
+
+		$url = set_url_scheme( self::current_url(), 'https' );
+		wp_redirect( $url, 301 );
+		exit;
 
 	}
 


### PR DESCRIPTION
Putting the method for forcing the scheme to HTTPS back in. Once we get "things" working on "stuff" (_hand waving_), this will be useful.

Removing the hook, so the method doesn't get called and cause issues.
